### PR TITLE
Use '#if canImport(Gedatsu)' instead of '#if DEBUG'

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ Gedatsu will start when after call `Gedatsu.open`.
 As an good example, call `Gedatsu.open` when `AppDelegate.application:didFinishLaunchingWithOptions:`.
 
 ```swift
-#if DEBUG
+#if canImport(Gedatsu)
 import Gedatsu
 #endif
 
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    #if DEBUG
+    #if canImport(Gedatsu)
     Gedatsu.open()
     #endif
     return true


### PR DESCRIPTION
Use '#if canImport(Gedatsu)' instead of '#if DEBUG'.
Because when you want to use Gedatsu in multiple configurations, you don't have to change '#if' macros.