### PR TITLE
Handling unknown defaults for NSLayoutConstraint.Attributes and Relation

### DIFF
--- a/Sources/Gedatsu/FormatterFunctions.swift
+++ b/Sources/Gedatsu/FormatterFunctions.swift
@@ -14,7 +14,7 @@ public func buildTreeContent(context: Context) -> String {
 }
 public func buildHeader(context: Context) -> String {
     var shouldShowErrorMessage = false
-    let validate: ([HasDisplayName]) -> Bool = { $0.allSatisfy(\.isValid) }
+    let validate: ([HasDisplayName]) -> Bool = { !$0.allSatisfy(\.isValid) }
     let content = context.exclusiveConstraints.compactMap { constraint in
         let address = addres(of: constraint)
         switch (constraint.firstItem, constraint.secondItem) {

--- a/Sources/Gedatsu/FormatterFunctions.swift
+++ b/Sources/Gedatsu/FormatterFunctions.swift
@@ -12,20 +12,26 @@ public func buildTreeContent(context: Context) -> String {
     }
     return content
 }
-public func buildHeader(context: Context) -> String {
-    return context.exclusiveConstraints.compactMap { constraint in
+public func buildHeader(context: Context) -> (String, Bool) {
+    var shouldShowErrorMessage = false
+    let validate: ([HasDisplayName]) -> Bool = { $0.allSatisfy(\.isValid) }
+    let content = context.exclusiveConstraints.compactMap { constraint in
         let address = addres(of: constraint)
         switch (constraint.firstItem, constraint.secondItem) {
         case (.none, .none):
             return "NSLayoutConstraint: \(address) Unknown case. \(constraint.displayIdentifier)"
         case (.some(let lhs), .some(let rhs)):
-            let (lAttribute, rAttribute) = (constraint.firstAttribute.displayName, constraint.secondAttribute.displayName)
+            let (lAttribute, rAttribute) = (constraint.firstAttribute, constraint.secondAttribute)
             let relation = constraint.relation
-            return "NSLayoutConstraint: \(address) \(itemType(of: lhs)).\(lAttribute) \(relation.displayName) \(itemType(of: rhs)).\(rAttribute) \(constraint.displayIdentifier)"
+            shouldShowErrorMessage = shouldShowErrorMessage || validate([lAttribute, rAttribute, relation])
+            return "NSLayoutConstraint: \(address) \(itemType(of: lhs)).\(lAttribute.displayName) \(relation.displayName) \(itemType(of: rhs)).\(rAttribute.displayName) \(constraint.displayIdentifier)"
         case (.some(let item), .none):
+            shouldShowErrorMessage = shouldShowErrorMessage || validate([constraint.firstAttribute, constraint.relation])
             return "NSLayoutConstraint: \(address) \(itemType(of: item)).\(constraint.firstAttribute.displayName) \(constraint.relation.displayName) \(constraint.constant) \(constraint.displayIdentifier)"
         case (.none, .some(let item)):
+            shouldShowErrorMessage = shouldShowErrorMessage || validate([constraint.secondAttribute, constraint.relation])
             return "NSLayoutConstraint: \(address) \(itemType(of: item)).\(constraint.secondAttribute.displayName) \(constraint.relation.displayName) \(constraint.constant) \(constraint.displayIdentifier)"
         }
     }.joined(separator: "\n")
+    return (content, shouldShowErrorMessage)
 }

--- a/Sources/Gedatsu/FormatterFunctions.swift
+++ b/Sources/Gedatsu/FormatterFunctions.swift
@@ -1,4 +1,9 @@
 import Foundation
+#if os(iOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
 
 public func buildTreeContent(context: Context) -> String {
     var content = ""
@@ -12,6 +17,7 @@ public func buildTreeContent(context: Context) -> String {
     }
     return content
 }
+
 public func buildHeader(context: Context) -> String {
     return context.exclusiveConstraints.compactMap { constraint in
         let address = addres(of: constraint)
@@ -19,13 +25,32 @@ public func buildHeader(context: Context) -> String {
         case (.none, .none):
             return "NSLayoutConstraint: \(address) Unknown case. \(constraint.displayIdentifier)"
         case (.some(let lhs), .some(let rhs)):
-            let (lAttribute, rAttribute) = (constraint.firstAttribute.displayName, constraint.secondAttribute.displayName)
+            let (lAttribute, rAttribute) = (constraint.firstAttribute, constraint.secondAttribute)
             let relation = constraint.relation
-            return "NSLayoutConstraint: \(address) \(itemType(of: lhs)).\(lAttribute) \(relation.displayName) \(itemType(of: rhs)).\(rAttribute) \(constraint.displayIdentifier)"
+            return buildHeaderContent(
+                displayables: [lAttribute, rAttribute, relation],
+                defaultContent: "NSLayoutConstraint: \(address) \(itemType(of: lhs)).\(lAttribute.displayName) \(relation.displayName) \(itemType(of: rhs)).\(rAttribute.displayName) \(constraint.displayIdentifier)"
+            )
         case (.some(let item), .none):
-            return "NSLayoutConstraint: \(address) \(itemType(of: item)).\(constraint.firstAttribute.displayName) \(constraint.relation.displayName) \(constraint.constant) \(constraint.displayIdentifier)"
+            return buildHeaderContent(displayables: [constraint.firstAttribute, constraint.relation], defaultContent: "NSLayoutConstraint: \(address) \(itemType(of: item)).\(constraint.firstAttribute.displayName) \(constraint.relation.displayName) \(constraint.constant) \(constraint.displayIdentifier)")
         case (.none, .some(let item)):
-            return "NSLayoutConstraint: \(address) \(itemType(of: item)).\(constraint.secondAttribute.displayName) \(constraint.relation.displayName) \(constraint.constant) \(constraint.displayIdentifier)"
+            return buildHeaderContent(displayables: [constraint.secondAttribute, constraint.relation], defaultContent: "NSLayoutConstraint: \(address) \(itemType(of: item)).\(constraint.secondAttribute.displayName) \(constraint.relation.displayName) \(constraint.constant) \(constraint.displayIdentifier)")
         }
     }.joined(separator: "\n")
+}
+
+private func buildHeaderContent(displayables: [HasDisplayName], defaultContent content: String) -> String {
+    let errorMessage = """
+Gedatsu catch unknown attribute or relation pattern. See issues for a solution to this problem. If that doesn't work, please create a new issue."
+https://github.com/bannzai/gedatsu/issues
+"""
+    switch displayables.allSatisfy(\.isValid) {
+    case true:
+        return content
+    case false:
+        return """
+        \(errorMessage)
+        \(content)
+        """
+    }
 }

--- a/Sources/Gedatsu/FormatterFunctions.swift
+++ b/Sources/Gedatsu/FormatterFunctions.swift
@@ -1,9 +1,4 @@
 import Foundation
-#if os(iOS)
-import UIKit
-#elseif os(macOS)
-import AppKit
-#endif
 
 public func buildTreeContent(context: Context) -> String {
     var content = ""
@@ -17,7 +12,6 @@ public func buildTreeContent(context: Context) -> String {
     }
     return content
 }
-
 public func buildHeader(context: Context) -> String {
     return context.exclusiveConstraints.compactMap { constraint in
         let address = addres(of: constraint)
@@ -25,32 +19,13 @@ public func buildHeader(context: Context) -> String {
         case (.none, .none):
             return "NSLayoutConstraint: \(address) Unknown case. \(constraint.displayIdentifier)"
         case (.some(let lhs), .some(let rhs)):
-            let (lAttribute, rAttribute) = (constraint.firstAttribute, constraint.secondAttribute)
+            let (lAttribute, rAttribute) = (constraint.firstAttribute.displayName, constraint.secondAttribute.displayName)
             let relation = constraint.relation
-            return buildHeaderContent(
-                displayables: [lAttribute, rAttribute, relation],
-                defaultContent: "NSLayoutConstraint: \(address) \(itemType(of: lhs)).\(lAttribute.displayName) \(relation.displayName) \(itemType(of: rhs)).\(rAttribute.displayName) \(constraint.displayIdentifier)"
-            )
+            return "NSLayoutConstraint: \(address) \(itemType(of: lhs)).\(lAttribute) \(relation.displayName) \(itemType(of: rhs)).\(rAttribute) \(constraint.displayIdentifier)"
         case (.some(let item), .none):
-            return buildHeaderContent(displayables: [constraint.firstAttribute, constraint.relation], defaultContent: "NSLayoutConstraint: \(address) \(itemType(of: item)).\(constraint.firstAttribute.displayName) \(constraint.relation.displayName) \(constraint.constant) \(constraint.displayIdentifier)")
+            return "NSLayoutConstraint: \(address) \(itemType(of: item)).\(constraint.firstAttribute.displayName) \(constraint.relation.displayName) \(constraint.constant) \(constraint.displayIdentifier)"
         case (.none, .some(let item)):
-            return buildHeaderContent(displayables: [constraint.secondAttribute, constraint.relation], defaultContent: "NSLayoutConstraint: \(address) \(itemType(of: item)).\(constraint.secondAttribute.displayName) \(constraint.relation.displayName) \(constraint.constant) \(constraint.displayIdentifier)")
+            return "NSLayoutConstraint: \(address) \(itemType(of: item)).\(constraint.secondAttribute.displayName) \(constraint.relation.displayName) \(constraint.constant) \(constraint.displayIdentifier)"
         }
     }.joined(separator: "\n")
-}
-
-private func buildHeaderContent(displayables: [HasDisplayName], defaultContent content: String) -> String {
-    let errorMessage = """
-Gedatsu catch unknown attribute or relation pattern. See issues for a solution to this problem. If that doesn't work, please create a new issue."
-https://github.com/bannzai/gedatsu/issues
-"""
-    switch displayables.allSatisfy(\.isValid) {
-    case true:
-        return content
-    case false:
-        return """
-        \(errorMessage)
-        \(content)
-        """
-    }
 }

--- a/Sources/Gedatsu/FormatterFunctions.swift
+++ b/Sources/Gedatsu/FormatterFunctions.swift
@@ -12,7 +12,7 @@ public func buildTreeContent(context: Context) -> String {
     }
     return content
 }
-public func buildHeader(context: Context) -> (String, Bool) {
+public func buildHeader(context: Context) -> String {
     var shouldShowErrorMessage = false
     let validate: ([HasDisplayName]) -> Bool = { $0.allSatisfy(\.isValid) }
     let content = context.exclusiveConstraints.compactMap { constraint in
@@ -33,5 +33,12 @@ public func buildHeader(context: Context) -> (String, Bool) {
             return "NSLayoutConstraint: \(address) \(itemType(of: item)).\(constraint.secondAttribute.displayName) \(constraint.relation.displayName) \(constraint.constant) \(constraint.displayIdentifier)"
         }
     }.joined(separator: "\n")
-    return (content, shouldShowErrorMessage)
+    if shouldShowErrorMessage {
+        return """
+        Gedatsu catch unknown attribute or relation pattern. See issues for a solution to this problem. If that doesn't solve, please create a new issue."
+        https://github.com/bannzai/gedatsu/issues
+        \(content)
+        """
+    }
+    return content
 }

--- a/Sources/Gedatsu/NSLayoutConstraintExtension.swift
+++ b/Sources/Gedatsu/NSLayoutConstraintExtension.swift
@@ -13,7 +13,24 @@ internal extension NSLayoutConstraint {
     }
 }
 
-internal extension NSLayoutConstraint.Attribute {
+internal protocol HasDisplayName {
+    var isValid: Bool { get }
+    var displayName: String { get }
+}
+
+extension NSLayoutConstraint.Attribute: HasDisplayName {
+    var isValid: Bool {
+        switch self {
+        case .left, .right, .top, .bottom, .leading, .trailing, .width, .height, .centerX, .centerY, .lastBaseline, .firstBaseline, .notAnAttribute:
+            return true
+            #if os(iOS)
+        case .leftMargin, .rightMargin, .topMargin, .bottomMargin, .leadingMargin, .trailingMargin, .centerXWithinMargins, .centerYWithinMargins:
+            return true
+            #endif
+        @unknown default:
+            return false
+        }
+    }
     var displayName: String {
         switch self {
         case .left:
@@ -61,11 +78,23 @@ internal extension NSLayoutConstraint.Attribute {
         case .notAnAttribute:
             return "notAnAttribute"
         @unknown default:
-            fatalError()
+            return "⚠️️️️⚠️️️️⚠️️️️ Unknown Attribute case for rawValue == \(rawValue) ⚠️️️️⚠️️️️⚠️️️️ "
         }
     }
 }
-internal extension NSLayoutConstraint.Relation {
+extension NSLayoutConstraint.Relation: HasDisplayName {
+    var isValid: Bool {
+        switch self {
+        case .equal:
+            return true
+        case .greaterThanOrEqual:
+            return true
+        case .lessThanOrEqual:
+            return true
+        @unknown default:
+            return false
+        }
+    }
     var displayName: String {
         switch self {
         case .equal:
@@ -75,7 +104,7 @@ internal extension NSLayoutConstraint.Relation {
         case .lessThanOrEqual:
             return "<="
         @unknown default:
-            fatalError()
+            return "⚠️️️️⚠️️️️⚠️️️️ Unknown Relation case for rawValue == \(rawValue) ⚠️️️️⚠️️️️⚠️️️️ "
         }
     }
 }


### PR DESCRIPTION
## Description 
No using blank fatalError when pass through to `switch ... @unknown default` statement. Handling this exception about pre check attributes and relation is valid before `buildHeader` content. The reason for creation PR of this [issue](https://github.com/bannzai/Gedatsu/issues/26) and it is closed: #26.